### PR TITLE
GPU friendly LightCollection for arbitrary lights

### DIFF
--- a/include/LightCollection.h
+++ b/include/LightCollection.h
@@ -15,14 +15,23 @@ namespace e186
 
 	public:
 		LightCollection() { }
-		LightCollection(int capacity) {
+		LightCollection(int capacity)
+		{
 			m_lights.reserve(capacity);
 			m_lights_gpu.reserve(capacity);
 			m_lights_extract.reserve(capacity);
 		}
-
+		LightCollection(const LightCollection& other) noexcept = default;
+		LightCollection(LightCollection&& other) noexcept = default;
+		LightCollection& operator=(const LightCollection& other) noexcept = default;
+		LightCollection& operator=(LightCollection&& other) noexcept = default;
 		~LightCollection() { }
-		
+
+		L_type& operator [](int i) { return m_lights[i]; }
+		L_type& at(int i) { return m_lights[i]; }
+		const size_t size() const { return m_lights.size(); }
+		const std::vector<L_gpu_type>& gpu_data() const { return m_lights_gpu; }
+
 		void Add(const L_type& light, fn_extract_gpu_data extract_gpu_data)
 		{
 			m_lights.push_back(light);
@@ -30,9 +39,13 @@ namespace e186
 			m_lights_gpu.push_back(extract_gpu_data(light));
 		}
 
-		L_type& operator [](int i)
+		L_type Remove(int i)
 		{
-			return m_lights[i];
+			L_type light = m_lights[i];
+			m_lights.erase(m_lights.begin() + i);
+			m_lights_gpu.erase(m_lights_gpu.begin() + i);
+			m_lights_extract.erase(m_lights_extract.begin() + i);
+			return light;
 		}
 
 		void UpdateGpuData(int i)
@@ -40,20 +53,9 @@ namespace e186
 			m_lights_gpu[i] = m_lights_extract[i](m_lights[i]);
 		}
 
-		const std::vector<L_gpu_type>& GetGpuData() const
-		{
-			return m_lights_gpu;
-		}
-
 		const void* GetGpuDataPtr() const
 		{
 			return &m_lights_gpu[0];
 		}
-
-		const size_t size() const 
-		{
-			return m_lights.size();
-		}
-
 	};
 }

--- a/include/LightCollection.h
+++ b/include/LightCollection.h
@@ -55,7 +55,7 @@ namespace e186
 
 		void UpdateGpuData()
 		{
-			for (size_t i = 0; i < 0; i++) {
+			for (size_t i = 0; i < size(); i++) {
 				m_lights_gpu[i] = m_lights_extract[i](m_lights[i]);
 			}
 			m_dirty = true;

--- a/include/LightCollection.h
+++ b/include/LightCollection.h
@@ -1,0 +1,59 @@
+#pragma once
+
+namespace e186
+{
+	template <typename L_type, typename L_gpu_type>
+	class LightCollection 
+	{
+	private:
+		typedef std::function<L_gpu_type(const L_type&)> fn_extract_gpu_data;
+
+		std::vector<L_type> m_lights;
+		std::vector<L_gpu_type> m_lights_gpu;
+		std::vector<fn_extract_gpu_data> m_lights_extract;
+
+
+	public:
+		LightCollection() { }
+		LightCollection(int capacity) {
+			m_lights.reserve(capacity);
+			m_lights_gpu.reserve(capacity);
+			m_lights_extract.reserve(capacity);
+		}
+
+		~LightCollection() { }
+		
+		void Add(const L_type& light, fn_extract_gpu_data extract_gpu_data)
+		{
+			m_lights.push_back(light);
+			m_lights_extract.push_back(extract_gpu_data);
+			m_lights_gpu.push_back(extract_gpu_data(light));
+		}
+
+		L_type& operator [](int i)
+		{
+			return m_lights[i];
+		}
+
+		void UpdateGpuData(int i)
+		{
+			m_lights_gpu[i] = m_lights_extract[i](m_lights[i]);
+		}
+
+		const std::vector<L_gpu_type>& GetGpuData() const
+		{
+			return m_lights_gpu;
+		}
+
+		const void* GetGpuDataPtr() const
+		{
+			return &m_lights_gpu[0];
+		}
+
+		const size_t size() const 
+		{
+			return m_lights.size();
+		}
+
+	};
+}

--- a/include/Shader.h
+++ b/include/Shader.h
@@ -61,12 +61,14 @@ namespace e186
 		Shader& QueryOptionalUniformLocation(const std::string& name);
 		Shader& QueryUniformLocation(const std::string& name);
 		Shader& QueryMandatoryUniformLocation(const std::string& name);
+		Shader& Shader::QueryUniformBlockIndex(const std::string& name);
 		Shader& DeclareAutoMatrix(std::string name, AutoMatrix properties);
 		Shader& Destroy();
 		bool HasUniform(const std::string& name) const;
 		GLuint GetOptionalUniformLocation(const std::string& name);
 		GLuint GetUniformLocation(const std::string& name);
 		GLuint GetMandatoryUniformLocation(const std::string& name);
+		GLuint GetUniformBlockIndex(const std::string& name);
 		bool has_tesselation_shaders() const;
 		GLint patch_vertices() const;
 		bool has_geometry_shader() const;
@@ -128,6 +130,11 @@ namespace e186
 		void SetUniform(GLuint location, const glm::mat4& value) const
 		{
 			glUniformMatrix4fv(location, 1, GL_FALSE, static_cast<const GLfloat*>(glm::value_ptr(value)));
+		}
+
+		void SetUniformBlockBinding(const std::string block_name, GLuint block_binding)
+		{
+			glUniformBlockBinding(m_prog_handle, GetUniformBlockIndex(block_name), block_binding);
 		}
 
 		void SetSampler(GLuint location, GLenum tex_target, GLuint tex_handle, GLuint texture_unit = 0) const
@@ -304,6 +311,7 @@ namespace e186
 		std::vector<std::string> m_compute_shader_sources;
 		std::vector<std::tuple<GLuint, const GLchar*>> m_fragment_outputs;
 		std::unordered_map<std::string, GLuint> m_uniform_locations;
+		std::unordered_map<std::string, GLuint> m_uniform_block_indices;
 		std::vector<const char*> m_transform_feedback_varyings;
 		GLenum m_transform_feedback_buffer_mode;
 		GLint m_patch_vertices;

--- a/include/e186.h
+++ b/include/e186.h
@@ -53,6 +53,7 @@
 #include "AmbientLight.h"
 #include "DirectionalLight.h"
 #include "PointLight.h"
+#include "LightCollection.h"
 #include "ShaderType.h"
 #include "Shader.h"
 #include "MaterialData.h"

--- a/project/e186.vcxproj
+++ b/project/e186.vcxproj
@@ -31,6 +31,7 @@
     <ClInclude Include="..\include\FixedSimulationTimer.h" />
     <ClInclude Include="..\include\FrameBufferObject.h" />
     <ClInclude Include="..\include\IScene.h" />
+    <ClInclude Include="..\include\LightCollection.h" />
     <ClInclude Include="..\include\LightsourceEditor.h" />
     <ClInclude Include="..\include\log.h" />
     <ClInclude Include="..\include\MaterialData.h" />

--- a/project/e186.vcxproj.filters
+++ b/project/e186.vcxproj.filters
@@ -264,6 +264,9 @@
     <ClInclude Include="..\external\include\FileWatcher\FileWatcher.h">
       <Filter>Header Files\external\FileWatcher</Filter>
     </ClInclude>
+    <ClInclude Include="..\include\LightCollection.h">
+      <Filter>Header Files\lightsources</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\src\e186stdafx.cpp">

--- a/src/Shader.cpp
+++ b/src/Shader.cpp
@@ -880,6 +880,23 @@ namespace e186
 		return *this;
 	}
 
+	Shader& Shader::QueryUniformBlockIndex(const std::string& name)
+	{
+		if (0 == m_prog_handle)
+		{
+			throw ExceptionWithCallstack("QueryUniformBlockIndex is useless since the program handle is 0");
+		}
+
+		glUseProgram(m_prog_handle);
+		auto loc = glGetUniformBlockIndex(m_prog_handle, name.c_str());
+		m_uniform_block_indices[name] = loc;
+		if (-1 == loc)
+		{
+			log_warning("Uniform block index of '%s' not found.", name.c_str());
+		}
+		return *this;
+	}
+
 	Shader& Shader::QueryMandatoryUniformLocation(const std::string& name)
 	{
 		QueryOptionalUniformLocation(name);
@@ -947,6 +964,17 @@ namespace e186
 		{
 			QueryUniformLocation(name);
 			return m_uniform_locations.at(name);
+		}
+		return loc->second;
+	}
+
+	GLuint Shader::GetUniformBlockIndex(const std::string& name)
+	{
+		const auto loc = m_uniform_block_indices.find(name);
+		if (loc == m_uniform_block_indices.end())
+		{
+			QueryUniformBlockIndex(name);
+			return m_uniform_block_indices.at(name);
 		}
 		return loc->second;
 	}


### PR DESCRIPTION
Added a collection for lights to store them in a GPU friendly manner, i.e. GPU data can be diretly uploaded to a buffer (UBO/SSBO) without copying the data of every light to a temporary buffer.